### PR TITLE
fix readme links, add taxonomy endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,12 @@ finished product via SCODE GitHub.
 ## Links to data:
 1. taxonomy.csv: This dataset explains the taxonomy codes applicable to different types of
 services
-https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/371dd944-411c
--4851-a065-9f3f605ddfb9
+https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/371dd944-411c-4851-a065-9f3f605ddfb9
 2. agency.csv: This dataset identifies the locations of agencies across Central Ohio region
-https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/570a8e02-fb0e-
-4cee-895b-3b32bd740650
+https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/570a8e02-fb0e-4cee-895b-3b32bd740650
 3. service_taxonomy.csv : This dataset presents the details about the taxonomy codes applicable
 to each agency. In other words, services offered at each agency are presented
-https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/2a919af7-12d3-
-47a4-b86a-56692e2e1623
+https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/2a919af7-12d3-47a4-b86a-56692e2e1623
 4. service_location.csv : This dataset contains additional information about the service locations,
 such as hours of operation:
 https://ckan.smartcolumbusos.com/dataset/b0390b58-35c9-45e8-8a2d-d2472b20d65f/resource/ec2

--- a/instrumenting.go
+++ b/instrumenting.go
@@ -10,15 +10,15 @@ import (
 type instrumentingMiddleware struct {
 	requestCount   metrics.Counter
 	requestLatency metrics.Histogram
-	next           FoodPantryService
+	next           TaxonomyService
 }
 
-func (mw instrumentingMiddleware) Providers() ([]Provider, error) {
+func (mw instrumentingMiddleware) Taxonomy() ([]Record, error) {
 	begin := time.Now()
-	providers, err := mw.next.Providers()
+	taxonomy, err := mw.next.Taxonomy()
 
-	lvs := []string{"method", "providers", "error", fmt.Sprint(err != nil)}
+	lvs := []string{"method", "taxonomys", "error", fmt.Sprint(err != nil)}
 	mw.requestCount.With(lvs...).Add(1)
 	mw.requestLatency.With(lvs...).Observe(time.Since(begin).Seconds())
-	return providers, err
+	return taxonomy, err
 }

--- a/logging.go
+++ b/logging.go
@@ -8,15 +8,16 @@ import (
 
 type loggingMiddleware struct {
 	logger log.Logger
-	next   FoodPantryService
+	next   TaxonomyService
 }
 
-func (mw loggingMiddleware) Providers() ([]Provider, error) {
+func (mw loggingMiddleware) Taxonomy() ([]Record, error) {
 	begin := time.Now()
-	output, err := mw.next.Providers()
+	output, err := mw.next.Taxonomy()
+	_ = mw.logger.Log("Output %v", output)
 
 	_ = mw.logger.Log(
-		"method", "providers",
+		"method", "taxonomys",
 		"input", "",
 		"err", err,
 		"took", time.Since(begin),

--- a/main.go
+++ b/main.go
@@ -29,18 +29,18 @@ func main() {
 		Help:      "Total duration of requests in microseconds.",
 	}, fieldKeys)
 
-	var svc FoodPantryService
-	svc = foodPantryService{}
+	var svc TaxonomyService
+	svc = taxonomyService{}
 	svc = loggingMiddleware{logger, svc}
 	svc = instrumentingMiddleware{requestCount, requestLatency, svc}
 
-	providerHandler := httptransport.NewServer(
-		makeProviderEndpoint(svc),
-		decodeProviderRequest,
+	taxonomyHandler := httptransport.NewServer(
+		makeTaxonomyEndpoint(svc),
+		decodeTaxonomyRequest,
 		encodeResponse,
 	)
 
-	http.Handle("/providers", providerHandler)
+	http.Handle("/taxonomys", taxonomyHandler)
 	http.Handle("/metrics", promhttp.Handler())
 	logger.Log("msg", "HTTP", "addr", ":8080")
 	logger.Log("err", http.ListenAndServe(":8080", nil))

--- a/service.go
+++ b/service.go
@@ -1,40 +1,79 @@
 package main
 
 import (
-	"time"
+	"encoding/json"
+	"io/ioutil"
+	http "net/http"
 )
 
-// FoodPantryService provides operations on strings.
-type FoodPantryService interface {
-	Providers() ([]Provider, error)
+// TaxonomyService provides operations on strings.
+type TaxonomyService interface {
+	Taxonomy() ([]Record, error)
 }
 
-type Provider struct {
-	ID                 int
-	Code               string
-	Description        string
-	Level              int
-	Active             string
-	DHSFlag            string
-	Text               string
-	BypassFollowupFlag string
-	VolunteerFlag      string
-	AddUser            string
-	AddDate            time.Time
-	SubCatID           int
-	DHSDescription     string
-	UpdateUser         string
-	UpdateDate         time.Time
+type Record struct {
+	ID                 int         `json:"_id"`
+	TAXONID            int         `json:"TAXON_ID"`
+	TAXONOMYCODE       string      `json:"TAXONOMY_CODE"`
+	DESCRIPTION        string      `json:"DESCRIPTION"`
+	TAXONOMYLEVEL      int         `json:"TAXONOMY_LEVEL"`
+	ACTIVEFLAG         string      `json:"ACTIVE_FLAG"`
+	DHSFLAG            string      `json:"DHS_FLAG"`
+	TEXT               string      `json:"TEXT"`
+	BYPASSFOLLOWUPFLAG string      `json:"BYPASS_FOLLOWUP_FLAG"`
+	VOLUNTEERFLAG      string      `json:"VOLUNTEER_FLAG"`
+	ADDUSER            string      `json:"ADD_USER"`
+	ADDDATE            string      `json:"ADD_DATE"`
+	TAXONIDSUBCATOF    interface{} `json:"TAXON_ID_SUBCAT_OF"`
+	DHSDESCRIPTION     string      `json:"DHS_DESCRIPTION"`
+	UPDATEUSER         string      `json:"UPDATE_USER"`
+	UPDATEDATE         string      `json:"UPDATE_DATE"`
 }
 
-type foodPantryService struct {
+type Taxonomy struct {
+	Help    string `json:"help"`
+	Success bool   `json:"success"`
+	Result  struct {
+		IncludeTotal bool   `json:"include_total"`
+		ResourceID   string `json:"resource_id"`
+		Fields       []struct {
+			Type string `json:"type"`
+			ID   string `json:"id"`
+		} `json:"fields"`
+		RecordsFormat string   `json:"records_format"`
+		Records       []Record `json:"records"`
+		Limit         int      `json:"limit"`
+		Links         struct {
+			Start string `json:"start"`
+			Next  string `json:"next"`
+		} `json:"_links"`
+		Total int `json:"total"`
+	} `json:"result"`
 }
 
-func (f foodPantryService) Providers() ([]Provider, error) {
-	return []Provider{
-		{
-			ID:          1,
-			Description: "Test Provider",
-		},
-	}, nil
+type taxonomyService struct {
+}
+
+func (f taxonomyService) Taxonomy() ([]Record, error) {
+	resp, err := http.Get("https://ckan.smartcolumbusos.com/api/3/action/datastore_search?resource_id=371dd944-411c-4851-a065-9f3f605ddfb9")
+
+	if err != nil {
+		return nil, err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+
+	if err != nil {
+		return nil, err
+	}
+
+	taxonomy := Taxonomy{}
+	err = json.Unmarshal(body, &taxonomy)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return taxonomy.Result.Records, nil
 }

--- a/transport.go
+++ b/transport.go
@@ -8,17 +8,17 @@ import (
 	"github.com/go-kit/kit/endpoint"
 )
 
-func makeProviderEndpoint(svc FoodPantryService) endpoint.Endpoint {
+func makeTaxonomyEndpoint(svc TaxonomyService) endpoint.Endpoint {
 	return func(_ context.Context, request interface{}) (interface{}, error) {
-		v, err := svc.Providers()
+		v, err := svc.Taxonomy()
 		if err != nil {
-			return providerResponse{v, err.Error()}, nil
+			return taxonomyResponse{v, err.Error()}, nil
 		}
-		return providerResponse{v, ""}, nil
+		return taxonomyResponse{v, ""}, nil
 	}
 }
 
-func decodeProviderRequest(_ context.Context, r *http.Request) (interface{}, error) {
+func decodeTaxonomyRequest(_ context.Context, r *http.Request) (interface{}, error) {
 	return nil, nil
 }
 
@@ -26,10 +26,10 @@ func encodeResponse(_ context.Context, w http.ResponseWriter, response interface
 	return json.NewEncoder(w).Encode(response)
 }
 
-type providerRequest struct {
+type taxonomyRequest struct {
 }
 
-type providerResponse struct {
-	Providers []Provider `json:"providers"`
-	Err       string     `json:"err,omitempty"`
+type taxonomyResponse struct {
+	Records []Record `json:"records"`
+	Err     string   `json:"err,omitempty"`
 }


### PR DESCRIPTION
Adds a basic endpoint to grab the data from https://ckan.smartcolumbusos.com/dataset/food-pantry-and-user-data/resource/371dd944-411c-4851-a065-9f3f605ddfb9

You can see the endpoint data from this endpoint http://localhost:8080/taxonomys.
 Fixes #5 